### PR TITLE
Double jump sound option

### DIFF
--- a/knytt/GDKnyttSettings.cs
+++ b/knytt/GDKnyttSettings.cs
@@ -257,6 +257,15 @@ public class GDKnyttSettings : Node
         }
     }
 
+    public static bool ClassicDoubleJumpSound
+    {
+        get { return ini["Audio"]["Classic Double Jump Sound"].Equals("1") ? true : false; }
+        set
+        {
+            ini["Audio"]["Classic Double Jump Sound"] = value ? "1" : "0";
+        }
+    }
+
     public static string UUID
     {
         get
@@ -377,6 +386,7 @@ public class GDKnyttSettings : Node
         modified |= ensureSetting("Audio", "Environment Volume", "80");
         modified |= ensureSetting("Audio", "Effects Volume", "70");
         modified |= ensureSetting("Audio", "Effects Panning", "1");
+        modified |= ensureSetting("Audio", "Classic Double Jump Sound", "1");
 
         modified |= ensureSetting("Server", "URL", "https://yknytt.pythonanywhere.com");
         modified |= ensureSetting("Server", "Connection", "Online");
@@ -412,6 +422,7 @@ public class GDKnyttSettings : Node
         EnvironmentVolume = int.Parse(ini["Audio"]["Environment Volume"]);
         EffectsVolume = int.Parse(ini["Audio"]["Effects Volume"]);
         EffectsPanning = floatParse(ini["Audio"]["Effects Panning"]);
+        ClassicDoubleJumpSound = ini["Audio"]["Classic Double Jump Sound"].Equals("1") ? true : false;
         StickSensitivity = floatParse(ini["Misc"]["Stick Sensitivity"]);
         LeftStickMovement = ini["Misc"]["Left Stick Movement"].Equals("1") ? true : false;
     }

--- a/knytt/GDKnyttSettings.cs
+++ b/knytt/GDKnyttSettings.cs
@@ -260,10 +260,7 @@ public class GDKnyttSettings : Node
     public static bool ClassicDoubleJumpSound
     {
         get { return ini["Audio"]["Classic Double Jump Sound"].Equals("1") ? true : false; }
-        set
-        {
-            ini["Audio"]["Classic Double Jump Sound"] = value ? "1" : "0";
-        }
+        set { ini["Audio"]["Classic Double Jump Sound"] = value ? "1" : "0"; }
     }
 
     public static string UUID

--- a/knytt/juni/Juni.cs
+++ b/knytt/juni/Juni.cs
@@ -854,7 +854,10 @@ public class Juni : KinematicBody2D
         if (air_jump && jumps > 0)
         {
             doubleJumpEffect();
-            if (sound) { GetNode<AudioStreamPlayer2D>("Audio/DoubleJumpPlayer2D").Play(); }
+            if (sound) {
+                string sound_path = GDKnyttSettings.ClassicDoubleJumpSound ? "Audio/DoubleJumpPlayer2D" :"Audio/JumpPlayer2D";
+                GetNode<AudioStreamPlayer2D>(sound_path).Play();
+            }
         }
 
         jumps = reset_jumps ? 1 : jumps + 1;

--- a/knytt/juni/Juni.cs
+++ b/knytt/juni/Juni.cs
@@ -780,10 +780,14 @@ public class Juni : KinematicBody2D
     {
         transitionState(new JumpState(this));
         Anim.Play(jump_speed < 0 ? "Jump" : "StartFall");
-        if (sound) { GetNode<AudioStreamPlayer2D>("Audio/JumpPlayer2D").Play(); }
+        if (sound && !air_jump) { GetNode<AudioStreamPlayer2D>("Audio/JumpPlayer2D").Play(); }
         velocity.y = jump_speed;
 
-        if (air_jump && jumps > 0) { doubleJumpEffect(); }
+        if (air_jump && jumps > 0)
+        {
+            doubleJumpEffect();
+            if (sound) { GetNode<AudioStreamPlayer2D>("Audio/DoubleJumpPlayer2D").Play(); }
+        }
 
         jumps = reset_jumps ? 1 : jumps + 1;
         JustClimbed = false;

--- a/knytt/juni/Juni.cs
+++ b/knytt/juni/Juni.cs
@@ -855,7 +855,7 @@ public class Juni : KinematicBody2D
         {
             doubleJumpEffect();
             if (sound) {
-                string sound_path = GDKnyttSettings.ClassicDoubleJumpSound ? "Audio/DoubleJumpPlayer2D" :"Audio/JumpPlayer2D";
+                string sound_path = GDKnyttSettings.ClassicDoubleJumpSound ? "Audio/DoubleJumpPlayer2D" : "Audio/JumpPlayer2D";
                 GetNode<AudioStreamPlayer2D>(sound_path).Play();
             }
         }

--- a/knytt/juni/Juni.tscn
+++ b/knytt/juni/Juni.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=48 format=2]
+[gd_scene load_steps=49 format=2]
 
 [ext_resource path="res://knytt/SFXAudioPlayer2D.tscn" type="PackedScene" id=1]
 [ext_resource path="res://knytt/juni/juni.png" type="Texture" id=2]
@@ -15,6 +15,7 @@
 [ext_resource path="res://knytt/juni/JuniAudio.cs" type="Script" id=13]
 [ext_resource path="res://knytt/data/Sfx/Knytt Jump (troupe).wav" type="AudioStream" id=14]
 [ext_resource path="res://knytt/juni/JuniMotionParticles.cs" type="Script" id=15]
+[ext_resource path="res://knytt/data/Sfx/Knytt Double Jump.wav" type="AudioStream" id=16]
 [ext_resource path="res://knytt/juni/Juni.shader" type="Shader" id=17]
 [ext_resource path="res://knytt/juni/StandartSoundPlayer.tscn" type="PackedScene" id=18]
 [ext_resource path="res://knytt/data/Sfx/Umbrella A.wav" type="AudioStream" id=19]
@@ -334,6 +335,10 @@ max_distance = 1000.0
 
 [node name="JumpPlayer2D" parent="Audio" instance=ExtResource( 1 )]
 stream = ExtResource( 14 )
+max_distance = 1000.0
+
+[node name="DoubleJumpPlayer2D" parent="Audio" instance=ExtResource( 1 )]
+stream = ExtResource( 16 )
 max_distance = 1000.0
 
 [node name="LandPlayer2D" parent="Audio" instance=ExtResource( 1 )]

--- a/knytt/ui/SettingsScreen.cs
+++ b/knytt/ui/SettingsScreen.cs
@@ -29,11 +29,12 @@ public class SettingsScreen : BasicScreen
         GetNode<OptionButton>("GeneralContainer/Misc/ShaderContainer/Shader").Select((int)GDKnyttSettings.Shader);
         GetNode<OptionButton>("GeneralContainer/Misc/OfflineDropdown").Select((int)GDKnyttSettings.Connection);
         
-        GetNode<Slider>("AudioContainer/MasterVolumeSlider").Value = GDKnyttSettings.MasterVolume;
-        GetNode<Slider>("AudioContainer/MusicVolumeSlider").Value = GDKnyttSettings.MusicVolume;
-        GetNode<Slider>("AudioContainer/EnvironmentVolumeSlider").Value = GDKnyttSettings.EnvironmentVolume;
-        GetNode<Slider>("AudioContainer/EffectsVolumeSlider").Value = GDKnyttSettings.EffectsVolume;
-        GetNode<Slider>("AudioContainer/EffectsPanningSlider").Value = GDKnyttSettings.EffectsPanning;
+        GetNode<Slider>("AudioContainer/SlidersContainer/MasterVolumeSlider").Value = GDKnyttSettings.MasterVolume;
+        GetNode<Slider>("AudioContainer/SlidersContainer/MusicVolumeSlider").Value = GDKnyttSettings.MusicVolume;
+        GetNode<Slider>("AudioContainer/SlidersContainer/EnvironmentVolumeSlider").Value = GDKnyttSettings.EnvironmentVolume;
+        GetNode<Slider>("AudioContainer/SlidersContainer/EffectsVolumeSlider").Value = GDKnyttSettings.EffectsVolume;
+        GetNode<Slider>("AudioContainer/SlidersContainer/EffectsPanningSlider").Value = GDKnyttSettings.EffectsPanning;
+        GetNode<CheckBox>("AudioContainer/OptionsContainer/ClassicDoubleJumpSound").Pressed = GDKnyttSettings.ClassicDoubleJumpSound;
 
         GetNode<CheckBox>("GeneralContainer/Graphics/FullScreen").Disabled = 
             GDKnyttSettings.Mobile || OS.GetName() == "HTML5" || OS.GetName() == "Unix";
@@ -205,7 +206,7 @@ public class SettingsScreen : BasicScreen
 
     private void updateVolumeLabel(string item, int value)
     {
-        GetNode<Label>($"AudioContainer/{item}VolumeLabel/Value").Text = $"{value}%";
+        GetNode<Label>($"AudioContainer/SlidersContainer/{item}VolumeLabel/Value").Text = $"{value}%";
     }
 
     private void _on_MasterVolumeSlider_value_changed(float value)
@@ -235,7 +236,12 @@ public class SettingsScreen : BasicScreen
     private void _on_EffectsPanningSlider_value_changed(float value)
     {
         GDKnyttSettings.EffectsPanning = value;
-        GetNode<Label>("AudioContainer/EffectsPanningLabel/Value").Text = $"{value:F2}x";
+        GetNode<Label>("AudioContainer/SlidersContainer/EffectsPanningLabel/Value").Text = $"{value:F2}x";
+    }
+    
+    private void _on_ClassicDoubleJumpSound_pressed()
+    {
+        GDKnyttSettings.ClassicDoubleJumpSound = GetNode<CheckBox>("AudioContainer/OptionsContainer/ClassicDoubleJumpSound").Pressed;
     }
 
     private void _on_Tab_focus_entered(string container_name)
@@ -277,7 +283,7 @@ public class SettingsScreen : BasicScreen
                                                 "KeysContainer/StickContainter/SensitivitySlider") :
             tab_button.Name == "TouchTab"   ? "TouchContainer/SwipeContainer/SwipeDefaultButton" :
             tab_button.Name == "DirTab"     ? "DirContainer/SavesContainer/BackupButton" :
-            tab_button.Name == "AudioTab"   ? "AudioContainer/EffectsPanningSlider" : "BackButton";
+            tab_button.Name == "AudioTab"   ? "AudioContainer/OptionsContainer/ClassicDoubleJumpSound" : "BackButton";
         GetNode<Control>(control_path).GrabFocus();
     }
 

--- a/knytt/ui/SettingsScreen.tscn
+++ b/knytt/ui/SettingsScreen.tscn
@@ -147,7 +147,7 @@ margin_right = 416.0
 margin_bottom = 30.0
 focus_neighbour_top = NodePath("../../BackButton")
 focus_neighbour_right = NodePath("../GeneralTab")
-focus_neighbour_bottom = NodePath("../../AudioContainer/MasterVolumeSlider")
+focus_neighbour_bottom = NodePath("../../AudioContainer/SlidersContainer/MasterVolumeSlider")
 focus_next = NodePath("../GeneralTab")
 custom_styles/focus = ExtResource( 9 )
 toggle_mode = true
@@ -1236,27 +1236,33 @@ mode_overrides_title = false
 mode = 2
 access = 2
 
-[node name="AudioContainer" type="VBoxContainer" parent="."]
+[node name="AudioContainer" type="HBoxContainer" parent="."]
 visible = false
 margin_left = 23.0
 margin_top = 50.0
-margin_right = 270.0
+margin_right = 523.0
 margin_bottom = 234.0
+mouse_filter = 2
+
+[node name="SlidersContainer" type="VBoxContainer" parent="AudioContainer"]
+margin_right = 247.0
+margin_bottom = 184.0
+rect_min_size = Vector2( 247, 0 )
 mouse_filter = 2
 custom_constants/separation = 1
 
-[node name="MasterVolumeLabel" type="HBoxContainer" parent="AudioContainer"]
+[node name="MasterVolumeLabel" type="HBoxContainer" parent="AudioContainer/SlidersContainer"]
 margin_right = 247.0
 margin_bottom = 13.0
 
-[node name="Label" type="Label" parent="AudioContainer/MasterVolumeLabel"]
+[node name="Label" type="Label" parent="AudioContainer/SlidersContainer/MasterVolumeLabel"]
 margin_right = 81.0
 margin_bottom = 13.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_fonts/font = ExtResource( 4 )
 text = "Master Volume:"
 
-[node name="Value" type="Label" parent="AudioContainer/MasterVolumeLabel"]
+[node name="Value" type="Label" parent="AudioContainer/SlidersContainer/MasterVolumeLabel"]
 margin_left = 85.0
 margin_right = 247.0
 margin_bottom = 13.0
@@ -1266,32 +1272,33 @@ custom_fonts/font = ExtResource( 4 )
 text = "100%"
 align = 2
 
-[node name="MasterVolumeSlider" type="HSlider" parent="AudioContainer"]
+[node name="MasterVolumeSlider" type="HSlider" parent="AudioContainer/SlidersContainer"]
 margin_top = 14.0
 margin_right = 247.0
 margin_bottom = 36.0
 rect_min_size = Vector2( 150, 22 )
-focus_neighbour_top = NodePath("../../TabsContainer/AudioTab")
-focus_previous = NodePath("../../TabsContainer/AudioTab")
+focus_neighbour_top = NodePath("../../../TabsContainer/AudioTab")
+focus_neighbour_right = NodePath("../../OptionsContainer/ClassicDoubleJumpSound")
+focus_previous = NodePath("../../../TabsContainer/AudioTab")
 custom_icons/grabber_highlight = ExtResource( 8 )
 custom_icons/grabber = ExtResource( 2 )
 custom_styles/slider = ExtResource( 7 )
 custom_styles/grabber_area_highlight = SubResource( 2 )
 custom_styles/grabber_area = SubResource( 3 )
 
-[node name="MusicVolumeLabel" type="HBoxContainer" parent="AudioContainer"]
+[node name="MusicVolumeLabel" type="HBoxContainer" parent="AudioContainer/SlidersContainer"]
 margin_top = 37.0
 margin_right = 247.0
 margin_bottom = 50.0
 
-[node name="Label" type="Label" parent="AudioContainer/MusicVolumeLabel"]
+[node name="Label" type="Label" parent="AudioContainer/SlidersContainer/MusicVolumeLabel"]
 margin_right = 76.0
 margin_bottom = 13.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_fonts/font = ExtResource( 4 )
 text = "Music Volume:"
 
-[node name="Value" type="Label" parent="AudioContainer/MusicVolumeLabel"]
+[node name="Value" type="Label" parent="AudioContainer/SlidersContainer/MusicVolumeLabel"]
 margin_left = 80.0
 margin_right = 247.0
 margin_bottom = 13.0
@@ -1301,30 +1308,31 @@ custom_fonts/font = ExtResource( 4 )
 text = "100%"
 align = 2
 
-[node name="MusicVolumeSlider" type="HSlider" parent="AudioContainer"]
+[node name="MusicVolumeSlider" type="HSlider" parent="AudioContainer/SlidersContainer"]
 margin_top = 51.0
 margin_right = 247.0
 margin_bottom = 73.0
 rect_min_size = Vector2( 150, 22 )
+focus_neighbour_right = NodePath("../../OptionsContainer/ClassicDoubleJumpSound")
 custom_icons/grabber_highlight = ExtResource( 8 )
 custom_icons/grabber = ExtResource( 2 )
 custom_styles/slider = ExtResource( 7 )
 custom_styles/grabber_area_highlight = SubResource( 4 )
 custom_styles/grabber_area = SubResource( 5 )
 
-[node name="EnvironmentVolumeLabel" type="HBoxContainer" parent="AudioContainer"]
+[node name="EnvironmentVolumeLabel" type="HBoxContainer" parent="AudioContainer/SlidersContainer"]
 margin_top = 74.0
 margin_right = 247.0
 margin_bottom = 87.0
 
-[node name="Label" type="Label" parent="AudioContainer/EnvironmentVolumeLabel"]
+[node name="Label" type="Label" parent="AudioContainer/SlidersContainer/EnvironmentVolumeLabel"]
 margin_right = 113.0
 margin_bottom = 13.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_fonts/font = ExtResource( 4 )
 text = "Environment Volume:"
 
-[node name="Value" type="Label" parent="AudioContainer/EnvironmentVolumeLabel"]
+[node name="Value" type="Label" parent="AudioContainer/SlidersContainer/EnvironmentVolumeLabel"]
 margin_left = 117.0
 margin_right = 247.0
 margin_bottom = 13.0
@@ -1334,30 +1342,31 @@ custom_fonts/font = ExtResource( 4 )
 text = "100%"
 align = 2
 
-[node name="EnvironmentVolumeSlider" type="HSlider" parent="AudioContainer"]
+[node name="EnvironmentVolumeSlider" type="HSlider" parent="AudioContainer/SlidersContainer"]
 margin_top = 88.0
 margin_right = 247.0
 margin_bottom = 110.0
 rect_min_size = Vector2( 150, 22 )
+focus_neighbour_right = NodePath("../../OptionsContainer/ClassicDoubleJumpSound")
 custom_icons/grabber_highlight = ExtResource( 8 )
 custom_icons/grabber = ExtResource( 2 )
 custom_styles/slider = ExtResource( 7 )
 custom_styles/grabber_area_highlight = SubResource( 8 )
 custom_styles/grabber_area = SubResource( 9 )
 
-[node name="EffectsVolumeLabel" type="HBoxContainer" parent="AudioContainer"]
+[node name="EffectsVolumeLabel" type="HBoxContainer" parent="AudioContainer/SlidersContainer"]
 margin_top = 111.0
 margin_right = 247.0
 margin_bottom = 124.0
 
-[node name="Label" type="Label" parent="AudioContainer/EffectsVolumeLabel"]
+[node name="Label" type="Label" parent="AudioContainer/SlidersContainer/EffectsVolumeLabel"]
 margin_right = 80.0
 margin_bottom = 13.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_fonts/font = ExtResource( 4 )
 text = "Effects Volume:"
 
-[node name="Value" type="Label" parent="AudioContainer/EffectsVolumeLabel"]
+[node name="Value" type="Label" parent="AudioContainer/SlidersContainer/EffectsVolumeLabel"]
 margin_left = 84.0
 margin_right = 247.0
 margin_bottom = 13.0
@@ -1367,30 +1376,31 @@ custom_fonts/font = ExtResource( 4 )
 text = "100%"
 align = 2
 
-[node name="EffectsVolumeSlider" type="HSlider" parent="AudioContainer"]
+[node name="EffectsVolumeSlider" type="HSlider" parent="AudioContainer/SlidersContainer"]
 margin_top = 125.0
 margin_right = 247.0
 margin_bottom = 147.0
 rect_min_size = Vector2( 150, 22 )
+focus_neighbour_right = NodePath("../../OptionsContainer/ClassicDoubleJumpSound")
 custom_icons/grabber_highlight = ExtResource( 8 )
 custom_icons/grabber = ExtResource( 2 )
 custom_styles/slider = ExtResource( 7 )
 custom_styles/grabber_area_highlight = SubResource( 6 )
 custom_styles/grabber_area = SubResource( 7 )
 
-[node name="EffectsPanningLabel" type="HBoxContainer" parent="AudioContainer"]
+[node name="EffectsPanningLabel" type="HBoxContainer" parent="AudioContainer/SlidersContainer"]
 margin_top = 148.0
 margin_right = 247.0
 margin_bottom = 161.0
 
-[node name="Label" type="Label" parent="AudioContainer/EffectsPanningLabel"]
+[node name="Label" type="Label" parent="AudioContainer/SlidersContainer/EffectsPanningLabel"]
 margin_right = 83.0
 margin_bottom = 13.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 custom_fonts/font = ExtResource( 4 )
 text = "Effects Panning:"
 
-[node name="Value" type="Label" parent="AudioContainer/EffectsPanningLabel"]
+[node name="Value" type="Label" parent="AudioContainer/SlidersContainer/EffectsPanningLabel"]
 margin_left = 87.0
 margin_right = 247.0
 margin_bottom = 13.0
@@ -1400,13 +1410,14 @@ custom_fonts/font = ExtResource( 4 )
 text = "100%"
 align = 2
 
-[node name="EffectsPanningSlider" type="HSlider" parent="AudioContainer"]
+[node name="EffectsPanningSlider" type="HSlider" parent="AudioContainer/SlidersContainer"]
 margin_top = 162.0
 margin_right = 247.0
 margin_bottom = 184.0
 rect_min_size = Vector2( 150, 22 )
-focus_neighbour_bottom = NodePath("../../BackButton")
-focus_next = NodePath("../../BackButton")
+focus_neighbour_right = NodePath("../../OptionsContainer/ClassicDoubleJumpSound")
+focus_neighbour_bottom = NodePath("../../../BackButton")
+focus_next = NodePath("../../OptionsContainer/ClassicDoubleJumpSound")
 custom_icons/grabber_highlight = ExtResource( 8 )
 custom_icons/grabber = ExtResource( 2 )
 custom_styles/slider = ExtResource( 7 )
@@ -1414,6 +1425,23 @@ custom_styles/grabber_area_highlight = SubResource( 6 )
 custom_styles/grabber_area = SubResource( 7 )
 max_value = 1.5
 step = 0.02
+
+[node name="OptionsContainer" type="VBoxContainer" parent="AudioContainer"]
+margin_left = 251.0
+margin_right = 498.0
+margin_bottom = 184.0
+rect_min_size = Vector2( 247, 0 )
+
+[node name="ClassicDoubleJumpSound" parent="AudioContainer/OptionsContainer" instance=ExtResource( 6 )]
+margin_right = 247.0
+margin_bottom = 33.0
+rect_min_size = Vector2( 0, 33 )
+focus_neighbour_left = NodePath("../../SlidersContainer/MasterVolumeSlider")
+focus_neighbour_top = NodePath("../../../TabsContainer/AudioTab")
+focus_neighbour_bottom = NodePath("../../../BackButton")
+focus_next = NodePath("../../../BackButton")
+focus_previous = NodePath("../../SlidersContainer/EffectsPanningSlider")
+text = "Classic double-jump sound"
 
 [connection signal="pressed" from="BackButton" to="." method="goBack"]
 [connection signal="focus_entered" from="ActiveTab" to="." method="_on_ActiveTab_focus_entered"]
@@ -1477,8 +1505,9 @@ step = 0.02
 [connection signal="popup_hide" from="DirContainer/SavesFileDialog" to="DirContainer" method="_on_FileDialog_popup_hide"]
 [connection signal="dir_selected" from="DirContainer/BackupFileDialog" to="DirContainer" method="_on_BackupFileDialog_dir_selected"]
 [connection signal="popup_hide" from="DirContainer/BackupFileDialog" to="DirContainer" method="_on_FileDialog_popup_hide"]
-[connection signal="value_changed" from="AudioContainer/MasterVolumeSlider" to="." method="_on_MasterVolumeSlider_value_changed"]
-[connection signal="value_changed" from="AudioContainer/MusicVolumeSlider" to="." method="_on_MusicVolumeSlider_value_changed"]
-[connection signal="value_changed" from="AudioContainer/EnvironmentVolumeSlider" to="." method="_on_EnvironmentVolumeSlider_value_changed"]
-[connection signal="value_changed" from="AudioContainer/EffectsVolumeSlider" to="." method="_on_EffectsVolumeSlider_value_changed"]
-[connection signal="value_changed" from="AudioContainer/EffectsPanningSlider" to="." method="_on_EffectsPanningSlider_value_changed"]
+[connection signal="value_changed" from="AudioContainer/SlidersContainer/MasterVolumeSlider" to="." method="_on_MasterVolumeSlider_value_changed"]
+[connection signal="value_changed" from="AudioContainer/SlidersContainer/MusicVolumeSlider" to="." method="_on_MusicVolumeSlider_value_changed"]
+[connection signal="value_changed" from="AudioContainer/SlidersContainer/EnvironmentVolumeSlider" to="." method="_on_EnvironmentVolumeSlider_value_changed"]
+[connection signal="value_changed" from="AudioContainer/SlidersContainer/EffectsVolumeSlider" to="." method="_on_EffectsVolumeSlider_value_changed"]
+[connection signal="value_changed" from="AudioContainer/SlidersContainer/EffectsPanningSlider" to="." method="_on_EffectsPanningSlider_value_changed"]
+[connection signal="pressed" from="AudioContainer/OptionsContainer/ClassicDoubleJumpSound" to="." method="_on_ClassicDoubleJumpSound_pressed"]


### PR DESCRIPTION
Resolves #179.

I understand you didn't want to merge PR #195 because you have gotten used to playing without the double jump sound. This PR is built on that one but adds a toggle to the audio settings so everyone can play with their preferred sound. The classic sound is enabled by default to match the original game.